### PR TITLE
Fix driver name query

### DIFF
--- a/pyvidctrl/__main__.py
+++ b/pyvidctrl/__main__.py
@@ -107,11 +107,11 @@ def query_ctrls(dev):
 
 def query_driver(dev):
     try:
-        cp = v4l2.v4l2_capability()
-        fcntl.ioctl(dev, v4l2.VIDIOC_QUERYCAP, cp)
+        cp = v4l2_capability()
+        ioctl(dev, VIDIOC_QUERYCAP, cp)
         return cp.driver
     except Exception:
-        return "unknown"
+        return b"unknown"
 
 
 class App(Widget):


### PR DESCRIPTION
Fix driver name query - tested on the Jetson Nano module and the imx586 camera sensor.