### PR TITLE
Parse text as utf-8

### DIFF
--- a/pyvidctrl/__main__.py
+++ b/pyvidctrl/__main__.py
@@ -58,7 +58,7 @@ def query_v4l2_ctrls(dev):
             break
 
         if ctrl.type == V4L2_CTRL_TYPE_CTRL_CLASS:
-            current_class = ctrl.name.decode("ascii")
+            current_class = ctrl.name.decode("utf-8")
             controls[current_class] = []
 
         controls[current_class].append(ctrl)
@@ -203,7 +203,7 @@ class App(Widget):
 
     def store_ctrls(self):
         driver = query_driver(self.device)
-        fname = ".pyvidctrl-" + driver.decode("ascii")
+        fname = ".pyvidctrl-" + driver.decode("utf-8")
 
         if not hasattr(self, "video_controller_tabs"):
             print(f"WARNING: Device {driver.decode('ascii')} has no controls")
@@ -228,7 +228,7 @@ class App(Widget):
 
     def restore_ctrls(self):
         driver = query_driver(self.device)
-        fname = ".pyvidctrl-" + driver.decode("ascii")
+        fname = ".pyvidctrl-" + driver.decode("utf-8")
 
         try:
             with open(fname, "r") as fd:

--- a/pyvidctrl/ctrl_widgets.py
+++ b/pyvidctrl/ctrl_widgets.py
@@ -24,7 +24,7 @@ class CtrlWidget(Row):
         self.device = device
         self.ctrl = ctrl
 
-        self.name = ctrl.name.decode("ascii")
+        self.name = ctrl.name.decode("utf-8")
         self.label = Label(self.name)
         self.widget = Label("Not implemented!", align="center")
 
@@ -231,7 +231,7 @@ class MenuCtrl(CtrlWidget):
             querymenu.index = i
             try:
                 ioctl(device, VIDIOC_QUERYMENU, querymenu)
-                options[i] = querymenu.name.decode("ascii")
+                options[i] = querymenu.name.decode("utf-8")
             except OSError:
                 # querymenu can fail for given index, but there can
                 # still be more valid indexes
@@ -417,7 +417,7 @@ class StringCtrl(CtrlWidget):
         except OSError:
             return None
 
-        return ectrl.string.decode("ascii")
+        return ectrl.string.decode("utf-8")
 
     @value.setter
     def value(self, value):
@@ -427,7 +427,7 @@ class StringCtrl(CtrlWidget):
 
         ectrl = v4l2_ext_control()
         ectrl.id = self.ctrl.id
-        ectrl.string = value.encode("ascii")
+        ectrl.string = value.encode("utf-8")
         ectrl.size = self.ctrl.elem_size
 
         ectrls = v4l2_ext_controls()


### PR DESCRIPTION
Apparently some cameras return utf-8 strings. This should be backwards
compatible with ascii so no need to try both.

Ref: #11