### PR TITLE
Add an option to pass a filename to (Re)store settings.

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9.4
+          python-version: '3.10'
       - name: Install flake8
         run: pip install -U flake8
       - name: Run flake8

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,4 +1,4 @@
-name: Flake8
+name: Code Quality Checks
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  flake8:
+  format:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -16,7 +16,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-      - name: Install flake8
-        run: pip install -U flake8
-      - name: Run flake8
-        run: flake8
+      - name: Install yapf
+        run: pip install yapf
+      - name: Format the code
+        run: |
+          python -m yapf -p -i pyvidctrl/*
+          test $(git status --porcelain | wc -l) -eq 0 || { git diff; false; }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *pyc
 /dist/
+venv
 /*.egg-info

--- a/README.md
+++ b/README.md
@@ -35,6 +35,15 @@ Features vi-like keybindings.
 |   ⏎   | negate value / click button                              |
 
 
+## Command Line Options
+
+| Option | Description                                                                                             |
+|--------|---------------------------------------------------------------------------------------------------------|
+| -r     | Restore current parameter values. Optionally takes a filename as an argument and restores from that file. If no filename is specified, it restores from a file named '.pyvidctrl-' followed by the driver name. |
+| -s     | Store current parameter values. Optionally takes a filename as an argument and saves to that file. If no filename is specified, it saves to a file named '.pyvidctrl-' followed by the driver name. |
+| -d     | Specifies the path to the camera device node or its ID. Default is "/dev/video0".                      |
+
+
 ## Installation
 
     pip install git+https://github.com/antmicro/pyvidctrl

--- a/pyvidctrl/__main__.py
+++ b/pyvidctrl/__main__.py
@@ -572,13 +572,13 @@ def main():
     if args.store and args.restore:
         print("Cannot store and restore values at the same time!")
         return 1
-    elif args.store is not True:
+    elif isinstance(args.store, str):
         print("Storing...")
         return app.store_ctrls(args.store)
     elif args.store:
         print("Storing...")
         return app.store_ctrls()
-    elif args.restore is not True:
+    elif isinstance(args.restore, str):
         print("Restoring...")
         return app.restore_ctrls(args.restore)
     elif args.restore:

--- a/pyvidctrl/__main__.py
+++ b/pyvidctrl/__main__.py
@@ -205,10 +205,9 @@ class App(Widget):
         if should_continue:
             return super().on_keypress(key)
 
-    def store_ctrls(self):
+    def store_ctrls(self, fname=None):
         driver = query_driver(self.device)
-        fname = ".pyvidctrl-" + driver.decode("utf-8")
-
+        fname = fname if fname else ".pyvidctrl-" + driver.decode("utf-8")
         if not hasattr(self, "video_controller_tabs"):
             print(f"WARNING: Device {driver.decode('ascii')} has no controls")
             with open(fname, "w") as fd:
@@ -230,10 +229,9 @@ class App(Widget):
 
         return 0
 
-    def restore_ctrls(self):
+    def restore_ctrls(self, fname=None):
         driver = query_driver(self.device)
-        fname = ".pyvidctrl-" + driver.decode("utf-8")
-
+        fname = fname if fname else ".pyvidctrl-" + driver.decode("utf-8")
         try:
             with open(fname, "r") as fd:
                 config = json.load(fd)
@@ -538,14 +536,18 @@ def main():
     parser.add_argument(
         "-s",
         "--store",
-        action="store_true",
-        help="Store current parameter values",
+        nargs='?',
+        const=True,
+        default=False,
+        help="Store current parameter values. Optionally takes a filename as an argument and saves to that file. If no filename is specified, it saves to a file named '.pyvidctrl-' followed by the driver name.",
     )
     parser.add_argument(
         "-r",
         "--restore",
-        action="store_true",
-        help="Restore current parameter values",
+        nargs='?',
+        const=True,
+        default=False,
+        help="Restore current parameter values. Optionally takes a filename as an argument and restores from that file. If no filename is specified, it restores from a file named '.pyvidctrl-' followed by the driver name.",
     )
     parser.add_argument(
         "-d",
@@ -570,9 +572,15 @@ def main():
     if args.store and args.restore:
         print("Cannot store and restore values at the same time!")
         return 1
+    elif args.store is not True:
+        print("Storing...")
+        return app.store_ctrls(args.store)
     elif args.store:
         print("Storing...")
         return app.store_ctrls()
+    elif args.restore is not True:
+        print("Restoring...")
+        return app.restore_ctrls(args.restore)
     elif args.restore:
         print("Restoring...")
         return app.restore_ctrls()

--- a/pyvidctrl/__main__.py
+++ b/pyvidctrl/__main__.py
@@ -115,6 +115,7 @@ def query_driver(dev):
 
 
 class App(Widget):
+
     def __init__(self, device):
         self.running = True
         self.in_help = False
@@ -539,7 +540,8 @@ def main():
         nargs='?',
         const=True,
         default=False,
-        help="Store current parameter values. Optionally takes a filename as an argument and saves to that file. If no filename is specified, it saves to a file named '.pyvidctrl-' followed by the driver name.",
+        help=
+        "Store current parameter values. Optionally takes a filename as an argument and saves to that file. If no filename is specified, it saves to a file named '.pyvidctrl-' followed by the driver name.",
     )
     parser.add_argument(
         "-r",
@@ -547,7 +549,8 @@ def main():
         nargs='?',
         const=True,
         default=False,
-        help="Restore current parameter values. Optionally takes a filename as an argument and restores from that file. If no filename is specified, it restores from a file named '.pyvidctrl-' followed by the driver name.",
+        help=
+        "Restore current parameter values. Optionally takes a filename as an argument and restores from that file. If no filename is specified, it restores from a file named '.pyvidctrl-' followed by the driver name.",
     )
     parser.add_argument(
         "-d",

--- a/pyvidctrl/ctrl_widgets.py
+++ b/pyvidctrl/ctrl_widgets.py
@@ -144,6 +144,7 @@ class IntCtrl(CtrlWidget):
     Integer type control widget
     Uses LabeledBar to display its value
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
         self.bar = BarLabeled(ctrl.minimum, ctrl.maximum, self.value)
@@ -189,6 +190,7 @@ class BoolCtrl(CtrlWidget):
     Boolean type control widget
     Uses TrueFalse to display its value
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
         self.widgets[2] = TrueFalse(self.value)
@@ -220,6 +222,7 @@ class MenuCtrl(CtrlWidget):
     Menu type control widget
     Uses Menu to display its value
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
 
@@ -274,6 +277,7 @@ class ButtonCtrl(CtrlWidget):
     Button type control widget
     Uses Button with 'Click me' text
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
         self.widgets[2] = Button("Click me")
@@ -318,6 +322,7 @@ class Int64Ctrl(IntCtrl):
     Integer64 type control widget
     Same as Integer one, except for statusline
     """
+
     @property
     def value(self):
         ectrl = v4l2_ext_control()
@@ -376,6 +381,7 @@ class CtrlClassCtrl(CtrlWidget):
     Removes second widget to show just its name,
     as it's just a category name control
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
         self.widgets = [Label(self.name, align="center")]
@@ -396,6 +402,7 @@ class StringCtrl(CtrlWidget):
     When minimum number of characters is not present, then spaces
     are appended at the end.
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
         self.text_field = TextField(self.value)
@@ -482,7 +489,9 @@ class BitmaskCtrl(CtrlWidget):
     Uses TextField to display its value.
     Limits possible characters to valid hex digits.
     """
+
     class BitmaskEditWidget(Widget):
+
         def __init__(self, value=0):
             self.value = value
             self.in_edit = False
@@ -652,6 +661,7 @@ class IntMenuCtrl(MenuCtrl):
     Just like MenuCtrl, but doesn't decode text representations
     of its values, as they are numbers.
     """
+
     def __init__(self, device, ctrl):
         super().__init__(device, ctrl)
 

--- a/pyvidctrl/video_controller.py
+++ b/pyvidctrl/video_controller.py
@@ -6,6 +6,7 @@ from .ctrl_widgets import *
 
 class VideoController(Widget):
     """Aggregates multiple CtrlWigets, manages and draws them."""
+
     def __init__(self, device, ctrls):
         self.ctrls = [c for c in ctrls if not isinstance(c, CtrlClassCtrl)]
         self.device = device

--- a/pyvidctrl/widgets.py
+++ b/pyvidctrl/widgets.py
@@ -51,6 +51,7 @@ class KeyBind:
 
 
 class Widget:
+
     @property
     def value(self):
         return self._value
@@ -93,6 +94,7 @@ class Row(Widget):
     Last widget in row, gets remaining width to
     fill given space.
     """
+
     def __init__(self, *widgets, columns=None):
         self.widgets = list(widgets)
         self.columns = columns or [1 for _ in widgets]
@@ -117,6 +119,7 @@ class Label(Widget):
     When there is not enough space, it is trimmed
     and one character '…' ellipsis is added at the end.
     """
+
     def __init__(self, text="", align="left"):
         assert align in ["left", "center", "right"]
         self.text = str(text)
@@ -146,6 +149,7 @@ class TextField(Widget):
     Requires another widget witch will catch events
     for it and manipulate its state.
     """
+
     def __init__(self, value="", align="left"):
         assert align in ["left", "center", "right"]
         self.value = str(value)
@@ -202,6 +206,7 @@ class Checkbox(Widget):
     Stores boolean and depending on value
     draws empty or checked box.
     """
+
     def __init__(self, value=False):
         self.value = value
 
@@ -216,6 +221,7 @@ class TrueFalse(Widget):
     Draws '[ ] False [ ] True' and depending on value
     checks box of one of them
     """
+
     def __init__(self, value=False):
         self.value = value
 
@@ -241,6 +247,7 @@ class Menu(Widget):
     `< option text >' and if the selected option
     is first or last, hides one of the arrows.
     """
+
     def __init__(self, options={}, selected=None):
         self.options = options
         self.keys = list(options.keys())
@@ -285,6 +292,7 @@ class Bar(Widget):
     Displays a number selection, by showing
     a circle on a number line.
     """
+
     def __init__(self, min, max, value=None):
         self.value = value if value is not None else min
         self.min = min
@@ -302,6 +310,7 @@ class Bar(Widget):
 
 class BarLabeled(Bar):
     """Bar containing a label"""
+
     def __init__(self, min, max, value=None, label_position="left"):
         super().__init__(min, max, value)
 
@@ -333,6 +342,7 @@ class Button(Widget):
     Simple button
     Right now it's just a label inside of square brackets
     """
+
     def __init__(self, text):
         self.text = text
 
@@ -342,6 +352,7 @@ class Button(Widget):
 
 
 class TabbedView(Widget):
+
     def __init__(self, widgets, titles=None, selected=None):
         assert 0 < len(widgets)
         self.widgets = widgets

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ except ImportError:
 
 setup(
     name='pyvidctrl',
-    version='1.0',
+    version='1.0.1',
     author='Antmicro Ltd',
     description="Simple TUI to control V4L2 cameras",
     author_email='contact@antmicro.com',


### PR DESCRIPTION
I have a use case where I'd like to swap between a few different sets of settings for the camera. To facilitate this, I've added an optional filename argument to the `-s` (store) and `-r` (restore) options.

Here are the changes I've made:

1. The `-s` and `-r` command line options can now take an optional filename as an argument. If specified, the current parameter values will be stored to or restored from this file. If no filename is specified, the program will default to the existing behavior of using a file named '.pyvidctrl-' followed by the driver name.

2. The `store_ctrls` and `restore_ctrls` methods in the App class have been updated to accept an optional filename argument.

3. The help text for the `-s` and `-r` options has been updated to reflect these changes.

4. I've updated the README.md to include a section on command line options, which details the usage of the `-r`, `-s`, and `-d` options. This provides users with a clear understanding of how they can use these options to control the behavior of the program.

These changes provide users with greater flexibility when using pyvidctrl, especially in use cases where there are multiple sets of camera settings that need to be regularly switched between.
